### PR TITLE
Replacing old inventory protecting with safe packet modifications usi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,6 +294,14 @@
 			<optional>true</optional>
 		</dependency>
 
+                <!--ProtocolLib http://dev.bukkit.org/bukkit-plugins/protocollib/ -->
+                <dependency>
+                    <groupId>com.comphenix.protocol</groupId>
+                    <artifactId>ProtocolLib</artifactId>
+                    <version>3.4.0</version>
+                    <optional>true</optional>
+                </dependency>
+
 		<!-- Vault, http://dev.bukkit.org/bukkit-plugins/vault/ -->
 		<dependency>
 			<groupId>net.milkbowl.vault</groupId>

--- a/src/main/java/fr/xephi/authme/cache/backup/DataFileCache.java
+++ b/src/main/java/fr/xephi/authme/cache/backup/DataFileCache.java
@@ -1,34 +1,15 @@
 package fr.xephi.authme.cache.backup;
 
-import org.bukkit.inventory.ItemStack;
-
 public class DataFileCache {
 
-    private ItemStack[] inventory;
-    private ItemStack[] armor;
     private String group;
     private boolean operator;
     private boolean flying;
 
-    public DataFileCache(ItemStack[] inventory, ItemStack[] armor) {
-        this(inventory, armor, "", false, false);
-    }
-
-    public DataFileCache(ItemStack[] inventory, ItemStack[] armor,
-            String group, boolean operator, boolean flying) {
-        this.inventory = inventory;
-        this.armor = armor;
+    public DataFileCache(String group, boolean operator, boolean flying) {
         this.group = group;
         this.operator = operator;
         this.flying = flying;
-    }
-
-    public ItemStack[] getInventory() {
-        return inventory;
-    }
-
-    public ItemStack[] getArmour() {
-        return armor;
     }
 
     public String getGroup() {

--- a/src/main/java/fr/xephi/authme/cache/limbo/LimboCache.java
+++ b/src/main/java/fr/xephi/authme/cache/limbo/LimboCache.java
@@ -11,7 +11,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -25,15 +24,13 @@ public class LimboCache {
     private LimboCache(AuthMe plugin) {
         this.plugin = plugin;
         this.cache = new ConcurrentHashMap<>();
-        this.playerData = new JsonCache(plugin);
+        this.playerData = new JsonCache();
     }
 
     public void addLimboPlayer(Player player) {
         String name = player.getName().toLowerCase();
         Location loc = player.getLocation();
         GameMode gameMode = player.getGameMode();
-        ItemStack[] arm;
-        ItemStack[] inv;
         boolean operator = false;
         String playerGroup = "";
         boolean flying = false;
@@ -42,12 +39,10 @@ public class LimboCache {
             final StoreInventoryEvent event = new StoreInventoryEvent(player, playerData);
             Bukkit.getServer().getPluginManager().callEvent(event);
             if (!event.isCancelled() && event.getInventory() != null && event.getArmor() != null) {
-                inv = event.getInventory();
-                arm = event.getArmor();
-            } else {
-                inv = null;
-                arm = null;
+                player.getInventory().setContents(event.getInventory());
+                player.getInventory().setArmorContents(event.getArmor());
             }
+
             DataFileCache cache = playerData.readCache(player);
             if (cache != null) {
                 playerGroup = cache.getGroup();
@@ -58,12 +53,10 @@ public class LimboCache {
             StoreInventoryEvent event = new StoreInventoryEvent(player);
             Bukkit.getServer().getPluginManager().callEvent(event);
             if (!event.isCancelled() && event.getInventory() != null && event.getArmor() != null) {
-                inv = event.getInventory();
-                arm = event.getArmor();
-            } else {
-                inv = null;
-                arm = null;
+                player.getInventory().setContents(event.getInventory());
+                player.getInventory().setArmorContents(event.getArmor());
             }
+
             operator = player.isOp();
             flying = player.isFlying();
             if (plugin.permission != null) {
@@ -93,7 +86,7 @@ public class LimboCache {
         if (player.isDead()) {
             loc = plugin.getSpawnLocation(player);
         }
-        cache.put(name, new LimboPlayer(name, loc, inv, arm, gameMode, operator, playerGroup, flying));
+        cache.put(name, new LimboPlayer(name, loc, gameMode, operator, playerGroup, flying));
     }
 
     public void addLimboPlayer(Player player, String group) {

--- a/src/main/java/fr/xephi/authme/cache/limbo/LimboPlayer.java
+++ b/src/main/java/fr/xephi/authme/cache/limbo/LimboPlayer.java
@@ -2,14 +2,11 @@ package fr.xephi.authme.cache.limbo;
 
 import org.bukkit.GameMode;
 import org.bukkit.Location;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitTask;
 
 public class LimboPlayer {
 
     private String name;
-    private ItemStack[] inventory;
-    private ItemStack[] armour;
     private Location loc = null;
     private BukkitTask timeoutTaskId = null;
     private BukkitTask messageTaskId = null;
@@ -17,19 +14,6 @@ public class LimboPlayer {
     private boolean operator = false;
     private String group = "";
     private boolean flying = false;
-
-    public LimboPlayer(String name, Location loc, ItemStack[] inventory,
-            ItemStack[] armour, GameMode gameMode, boolean operator,
-            String group, boolean flying) {
-        this.name = name;
-        this.loc = loc;
-        this.inventory = inventory;
-        this.armour = armour;
-        this.gameMode = gameMode;
-        this.operator = operator;
-        this.group = group;
-        this.flying = flying;
-    }
 
     public LimboPlayer(String name, Location loc, GameMode gameMode,
             boolean operator, String group, boolean flying) {
@@ -52,22 +36,6 @@ public class LimboPlayer {
 
     public Location getLoc() {
         return loc;
-    }
-
-    public ItemStack[] getArmour() {
-        return armour;
-    }
-
-    public ItemStack[] getInventory() {
-        return inventory;
-    }
-
-    public void setArmour(ItemStack[] armour) {
-        this.armour = armour;
-    }
-
-    public void setInventory(ItemStack[] inventory) {
-        this.inventory = inventory;
     }
 
     public GameMode getGameMode() {
@@ -105,5 +73,4 @@ public class LimboPlayer {
     public boolean isFlying() {
         return flying;
     }
-
 }

--- a/src/main/java/fr/xephi/authme/commands/UnregisterCommand.java
+++ b/src/main/java/fr/xephi/authme/commands/UnregisterCommand.java
@@ -18,7 +18,6 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitScheduler;
@@ -34,7 +33,7 @@ public class UnregisterCommand implements CommandExecutor {
 
     public UnregisterCommand(AuthMe plugin) {
         this.plugin = plugin;
-        this.playerCache = new JsonCache(plugin);
+        this.playerCache = new JsonCache();
     }
 
     @Override
@@ -79,8 +78,7 @@ public class UnregisterCommand implements CommandExecutor {
                                     player.teleport(tpEvent.getTo());
                                 }
                             }
-                            player.getInventory().setContents(new ItemStack[36]);
-                            player.getInventory().setArmorContents(new ItemStack[4]);
+                            
                             player.saveData();
                             PlayerCache.getInstance().removePlayer(player.getName().toLowerCase());
                             if (!Settings.getRegisteredGroup.isEmpty())

--- a/src/main/java/fr/xephi/authme/events/ProtectInventoryEvent.java
+++ b/src/main/java/fr/xephi/authme/events/ProtectInventoryEvent.java
@@ -4,7 +4,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 /**
- * 
+ *
  * This event is call just after store inventory into cache and will empty the
  * player inventory.
  *
@@ -18,12 +18,11 @@ public class ProtectInventoryEvent extends CustomEvent {
     private ItemStack[] emptyArmor = null;
     private Player player;
 
-    public ProtectInventoryEvent(Player player, ItemStack[] storedinventory,
-            ItemStack[] storedarmor) {
+    public ProtectInventoryEvent(Player player) {
         super(true);
         this.player = player;
-        this.storedinventory = storedinventory;
-        this.storedarmor = storedarmor;
+        this.storedinventory = player.getInventory().getContents();
+        this.storedarmor = player.getInventory().getArmorContents();
         this.emptyInventory = new ItemStack[36];
         this.emptyArmor = new ItemStack[4];
     }

--- a/src/main/java/fr/xephi/authme/events/RestoreInventoryEvent.java
+++ b/src/main/java/fr/xephi/authme/events/RestoreInventoryEvent.java
@@ -4,8 +4,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 /**
- *
- * This event restore the inventory from cache
+ * This event restore the inventory.
  *
  * @author Xephi59
  */
@@ -15,16 +14,14 @@ public class RestoreInventoryEvent extends CustomEvent {
     private ItemStack[] armor;
     private Player player;
 
-    public RestoreInventoryEvent(Player player, ItemStack[] inventory,
-            ItemStack[] armor) {
+    public RestoreInventoryEvent(Player player) {
         this.player = player;
-        this.inventory = inventory;
-        this.armor = armor;
+        this.inventory = player.getInventory().getContents();
+        this.armor = player.getInventory().getArmorContents();
     }
 
-    public RestoreInventoryEvent(Player player, ItemStack[] inventory,
-            ItemStack[] armor, boolean b) {
-        super(b);
+    public RestoreInventoryEvent(Player player, boolean async) {
+        super(async);
         this.player = player;
         this.inventory = inventory;
         this.armor = armor;
@@ -53,5 +50,4 @@ public class RestoreInventoryEvent extends CustomEvent {
     public void setPlayer(Player player) {
         this.player = player;
     }
-
 }

--- a/src/main/java/fr/xephi/authme/events/StoreInventoryEvent.java
+++ b/src/main/java/fr/xephi/authme/events/StoreInventoryEvent.java
@@ -1,6 +1,5 @@
 package fr.xephi.authme.events;
 
-import fr.xephi.authme.cache.backup.DataFileCache;
 import fr.xephi.authme.cache.backup.JsonCache;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -24,14 +23,8 @@ public class StoreInventoryEvent extends CustomEvent {
 
     public StoreInventoryEvent(Player player, JsonCache jsonCache) {
         this.player = player;
-        DataFileCache cache = jsonCache.readCache(player);
-        if (cache != null) {
-            this.inventory = cache.getInventory();
-            this.armor = cache.getArmour();
-        } else {
-            this.inventory = player.getInventory().getContents();
-            this.armor = player.getInventory().getArmorContents();
-        }
+        this.inventory = player.getInventory().getContents();
+        this.armor = player.getInventory().getArmorContents();
     }
 
     public ItemStack[] getInventory() {
@@ -57,5 +50,4 @@ public class StoreInventoryEvent extends CustomEvent {
     public void setPlayer(Player player) {
         this.player = player;
     }
-
 }

--- a/src/main/java/fr/xephi/authme/listener/AuthMeInventoryListener.java
+++ b/src/main/java/fr/xephi/authme/listener/AuthMeInventoryListener.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2015 AuthMe-Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package fr.xephi.authme.listener;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.events.PacketEvent;
+
+import fr.xephi.authme.AuthMe;
+import fr.xephi.authme.cache.auth.PlayerCache;
+import fr.xephi.authme.settings.Settings;
+
+import java.lang.reflect.InvocationTargetException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.logging.Level;
+
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+public class AuthMeInventoryListener extends PacketAdapter {
+
+    private static final int PLAYER_INVENTORY = 0;
+    //http://wiki.vg/Inventory#Inventory (0-4 crafting, 5-8 armor, 9-35 main inventory, 36-44 inventory)
+    //+1 because an index starts with 0
+    private static final int PLAYER_CRAFTING_SIZE = 5;
+    private static final int HOTBAR_SIZE = 9;
+
+    public AuthMeInventoryListener(AuthMe plugin) {
+        super(plugin, PacketType.Play.Server.SET_SLOT, PacketType.Play.Server.WINDOW_ITEMS);
+    }
+
+    @Override
+    public void onPacketSending(PacketEvent packetEvent) {
+        Player player = packetEvent.getPlayer();
+        PacketContainer packet = packetEvent.getPacket();
+
+        byte windowId = packet.getIntegers().read(0).byteValue();
+        if (windowId == PLAYER_INVENTORY && Settings.protectInventoryBeforeLogInEnabled
+                && !PlayerCache.getInstance().isAuthenticated(player.getName())) {
+            packetEvent.setCancelled(true);
+        }
+    }
+
+    public void sendInventoryPacket(Player player) {
+        ProtocolManager protocolManager = ProtocolLibrary.getProtocolManager();
+        PacketContainer inventoryPacket = protocolManager.createPacket(PacketType.Play.Server.WINDOW_ITEMS);
+
+        //we are sending our own inventory
+        inventoryPacket.getIntegers().write(0, PLAYER_INVENTORY);
+
+        ItemStack[] playerCrafting = new ItemStack[PLAYER_CRAFTING_SIZE];
+        ItemStack[] armorContents = player.getInventory().getArmorContents();
+        ItemStack[] mainInventory = player.getInventory().getContents();
+
+        //bukkit saves the armor in reversed order
+        Collections.reverse(Arrays.asList(armorContents));
+
+        //same main inventory. The hotbar is at the beginning but it should be at the end of the array
+        ItemStack[] hotbar = Arrays.copyOfRange(mainInventory, 0, HOTBAR_SIZE);
+        ItemStack[] storedInventory = Arrays.copyOfRange(mainInventory, HOTBAR_SIZE, mainInventory.length);
+
+        //concat all parts of the inventory together
+        int inventorySize = playerCrafting.length + armorContents.length + mainInventory.length;
+        ItemStack[] completeInventory = new ItemStack[inventorySize];
+
+        System.arraycopy(playerCrafting, 0, completeInventory, 0, playerCrafting.length);
+        System.arraycopy(armorContents, 0, completeInventory, playerCrafting.length, armorContents.length);
+
+        //storedInventory and hotbar
+        System.arraycopy(storedInventory, 0, completeInventory
+                , playerCrafting.length + armorContents.length, storedInventory.length);
+        System.arraycopy(hotbar, 0, completeInventory
+                , playerCrafting.length + armorContents.length + storedInventory.length, hotbar.length);
+
+        inventoryPacket.getItemArrayModifier().write(0, completeInventory);
+        try {
+            protocolManager.sendServerPacket(player, inventoryPacket, false);
+        } catch (InvocationTargetException invocationExc) {
+            plugin.getLogger().log(Level.WARNING, "Error during inventory recovery", invocationExc);
+        }
+    }
+}

--- a/src/main/java/fr/xephi/authme/listener/AuthMeServerListener.java
+++ b/src/main/java/fr/xephi/authme/listener/AuthMeServerListener.java
@@ -68,6 +68,10 @@ public class AuthMeServerListener implements Listener {
             plugin.permission = null;
             ConsoleLogger.showError("Vault has been disabled, unhook permissions!");
         }
+        if (pluginName.equalsIgnoreCase("ProtocolLib")) {
+            plugin.inventoryProtector = null;
+            ConsoleLogger.showError("ProtocolLib has been disabled, unhook packet inventory protection!");
+        }
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)
@@ -83,5 +87,8 @@ public class AuthMeServerListener implements Listener {
             plugin.checkCombatTagPlus();
         if (pluginName.equalsIgnoreCase("Vault"))
             plugin.checkVault();
+        if (pluginName.equalsIgnoreCase("ProtocolLib")) {
+            plugin.checkProtocolLib();
+        }
     }
 }

--- a/src/main/java/fr/xephi/authme/process/login/ProcessSyncronousPlayerLogin.java
+++ b/src/main/java/fr/xephi/authme/process/login/ProcessSyncronousPlayerLogin.java
@@ -42,7 +42,7 @@ public class ProcessSyncronousPlayerLogin implements Runnable {
         this.name = player.getName().toLowerCase();
         this.limbo = LimboCache.getInstance().getLimboPlayer(name);
         this.auth = database.getAuth(name);
-        this.playerCache = new JsonCache(plugin);
+        this.playerCache = new JsonCache();
     }
 
     public LimboPlayer getLimbo() {
@@ -92,10 +92,11 @@ public class ProcessSyncronousPlayerLogin implements Runnable {
     }
 
     protected void restoreInventory() {
-        RestoreInventoryEvent event = new RestoreInventoryEvent(player, limbo.getInventory(), limbo.getArmour());
+        RestoreInventoryEvent event = new RestoreInventoryEvent(player);
         Bukkit.getServer().getPluginManager().callEvent(event);
         if (!event.isCancelled()) {
             plugin.api.setPlayerInventory(player, event.getInventory(), event.getArmor());
+            plugin.inventoryProtector.sendInventoryPacket(player);
         }
     }
 
@@ -128,7 +129,7 @@ public class ProcessSyncronousPlayerLogin implements Runnable {
             // Inventory - Make it after restore GameMode , cause we need to
             // restore the
             // right inventory in the right gamemode
-            if (Settings.protectInventoryBeforeLogInEnabled && player.hasPlayedBefore()) {
+            if (Settings.protectInventoryBeforeLogInEnabled  && plugin.inventoryProtector != null) {
                 restoreInventory();
             }
             if (Settings.forceOnlyAfterLogin) {

--- a/src/main/java/fr/xephi/authme/process/logout/AsyncronousLogout.java
+++ b/src/main/java/fr/xephi/authme/process/logout/AsyncronousLogout.java
@@ -9,8 +9,6 @@ import fr.xephi.authme.Utils;
 import fr.xephi.authme.Utils.GroupType;
 import fr.xephi.authme.cache.auth.PlayerAuth;
 import fr.xephi.authme.cache.auth.PlayerCache;
-import fr.xephi.authme.cache.backup.DataFileCache;
-import fr.xephi.authme.cache.backup.JsonCache;
 import fr.xephi.authme.cache.limbo.LimboCache;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.events.AuthMeTeleportEvent;
@@ -25,7 +23,6 @@ public class AsyncronousLogout {
     protected DataSource database;
     protected boolean canLogout = true;
     private Messages m = Messages.getInstance();
-    private JsonCache playerBackup;
 
     public AsyncronousLogout(Player player, AuthMe plugin,
             DataSource database) {
@@ -33,7 +30,6 @@ public class AsyncronousLogout {
         this.plugin = plugin;
         this.database = database;
         this.name = player.getName().toLowerCase();
-        this.playerBackup = new JsonCache(plugin);
     }
 
     private void preLogout() {
@@ -79,13 +75,7 @@ public class AsyncronousLogout {
             LimboCache.getInstance().deleteLimboPlayer(name);
         LimboCache.getInstance().addLimboPlayer(player);
         Utils.setGroup(player, GroupType.NOTLOGGEDIN);
-        if (Settings.protectInventoryBeforeLogInEnabled) {
-            player.getInventory().clear();
-            // create cache file for handling lost of inventories on unlogged in
-            // status
-            DataFileCache playerData = new DataFileCache(LimboCache.getInstance().getLimboPlayer(name).getInventory(), LimboCache.getInstance().getLimboPlayer(name).getArmour());
-            playerBackup.createCache(player, playerData);
-        }
+
         sched.scheduleSyncDelayedTask(plugin, new ProcessSyncronousPlayerLogout(p, plugin));
     }
 }

--- a/src/main/java/fr/xephi/authme/process/quit/AsyncronousQuit.java
+++ b/src/main/java/fr/xephi/authme/process/quit/AsyncronousQuit.java
@@ -3,7 +3,6 @@ package fr.xephi.authme.process.quit;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitTask;
 
 import fr.xephi.authme.AuthMe;
@@ -13,7 +12,6 @@ import fr.xephi.authme.cache.auth.PlayerCache;
 import fr.xephi.authme.cache.limbo.LimboCache;
 import fr.xephi.authme.cache.limbo.LimboPlayer;
 import fr.xephi.authme.datasource.DataSource;
-import fr.xephi.authme.events.RestoreInventoryEvent;
 import fr.xephi.authme.listener.AuthMePlayerListener;
 import fr.xephi.authme.settings.Settings;
 
@@ -23,8 +21,6 @@ public class AsyncronousQuit {
     protected DataSource database;
     protected Player player;
     private String name;
-    private ItemStack[] armor = null;
-    private ItemStack[] inv = null;
     private boolean isOp = false;
     private boolean isFlying = false;
     private boolean needToChange = false;
@@ -60,10 +56,6 @@ public class AsyncronousQuit {
 
         if (LimboCache.getInstance().hasLimboPlayer(name)) {
             LimboPlayer limbo = LimboCache.getInstance().getLimboPlayer(name);
-            if (Settings.protectInventoryBeforeLogInEnabled && player.hasPlayedBefore()) {
-                inv = limbo.getInventory();
-                armor = limbo.getArmour();
-            }
             if (limbo.getGroup() != null && !limbo.getGroup().equals(""))
                 Utils.addNormal(player, limbo.getGroup());
             needToChange = true;
@@ -94,17 +86,8 @@ public class AsyncronousQuit {
             PlayerCache.getInstance().removePlayer(name);
             database.setUnlogged(name);
         }
+
         AuthMePlayerListener.gameMode.remove(name);
-        final Player p = player;
-        RestoreInventoryEvent ev = new RestoreInventoryEvent(player, inv, armor, true);
-        Bukkit.getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
-            inv = null;
-            armor = null;
-        } else {
-            inv = ev.getInventory();
-            armor = ev.getArmor();
-        }
-        Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, new ProcessSyncronousPlayerQuit(plugin, p, inv, armor, isOp, isFlying, needToChange));
+        Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, new ProcessSyncronousPlayerQuit(plugin, player, isOp, isFlying, needToChange));
     }
 }

--- a/src/main/java/fr/xephi/authme/process/quit/ProcessSyncronousPlayerQuit.java
+++ b/src/main/java/fr/xephi/authme/process/quit/ProcessSyncronousPlayerQuit.java
@@ -2,10 +2,11 @@ package fr.xephi.authme.process.quit;
 
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 
 import fr.xephi.authme.AuthMe;
+import fr.xephi.authme.events.RestoreInventoryEvent;
 import fr.xephi.authme.settings.Settings;
+import org.bukkit.Bukkit;
 
 public class ProcessSyncronousPlayerQuit implements Runnable {
 
@@ -13,26 +14,26 @@ public class ProcessSyncronousPlayerQuit implements Runnable {
     protected Player player;
     protected boolean isOp;
     protected boolean isFlying;
-    protected ItemStack[] inv;
-    protected ItemStack[] armor;
     protected boolean needToChange;
 
-    public ProcessSyncronousPlayerQuit(AuthMe plugin, Player player,
-            ItemStack[] inv, ItemStack[] armor, boolean isOp, boolean isFlying,
-            boolean needToChange) {
+    public ProcessSyncronousPlayerQuit(AuthMe plugin, Player player
+            , boolean isOp, boolean isFlying
+            , boolean needToChange) {
         this.plugin = plugin;
         this.player = player;
         this.isOp = isOp;
         this.isFlying = isFlying;
-        this.armor = armor;
-        this.inv = inv;
         this.needToChange = needToChange;
     }
 
     @Override
     public void run() {
-        if (inv != null && armor != null)
-            plugin.api.setPlayerInventory(player, inv, armor);
+        RestoreInventoryEvent ev = new RestoreInventoryEvent(player);
+        Bukkit.getPluginManager().callEvent(ev);
+        if (!ev.isCancelled()) {
+            plugin.api.setPlayerInventory(player, ev.getInventory(), ev.getArmor());
+        }
+
         if (needToChange) {
             player.setOp(isOp);
             if (player.getGameMode() != GameMode.CREATIVE && !Settings.isMovementAllowed) {

--- a/src/main/java/fr/xephi/authme/process/register/ProcessSyncronousPasswordRegister.java
+++ b/src/main/java/fr/xephi/authme/process/register/ProcessSyncronousPasswordRegister.java
@@ -91,14 +91,17 @@ public class ProcessSyncronousPasswordRegister implements Runnable {
                     player.teleport(tpEvent.getTo());
                 }
             }
-            if (Settings.protectInventoryBeforeLogInEnabled && limbo.getInventory() != null && limbo.getArmour() != null) {
-                RestoreInventoryEvent event = new RestoreInventoryEvent(player, limbo.getInventory(), limbo.getArmour());
+
+            if (Settings.protectInventoryBeforeLogInEnabled && plugin.inventoryProtector != null) {
+                RestoreInventoryEvent event = new RestoreInventoryEvent(player);
                 Bukkit.getPluginManager().callEvent(event);
                 if (!event.isCancelled() && event.getArmor() != null && event.getInventory() != null) {
                     player.getInventory().setContents(event.getInventory());
                     player.getInventory().setArmorContents(event.getArmor());
+                    plugin.inventoryProtector.sendInventoryPacket(player);
                 }
             }
+
             limbo.getTimeoutTaskId().cancel();
             limbo.getMessageTaskId().cancel();
             LimboCache.getInstance().deleteLimboPlayer(name);
@@ -153,6 +156,5 @@ public class ProcessSyncronousPasswordRegister implements Runnable {
 
         // Register is now finish , we can force all commands
         forceCommands();
-
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ website: http://dev.bukkit.org/bukkit-plugins/authme-reloaded/
 description: AuthMe prevents people, which aren't logged in, from doing stuff like placing blocks, moving, typing commands or seeing the inventory of the player.
 main: fr.xephi.authme.AuthMe
 version: ${project.version}
-softdepend: [Vault, ChestShop, Multiverse-Core, Citizens, CombatTag, Essentials, EssentialsSpawn, PerWorldInventories]
+softdepend: [Vault, ChestShop, Multiverse-Core, Citizens, CombatTag, Essentials, EssentialsSpawn, PerWorldInventories, ProtocolLib]
 commands:
     register:
         description: Register an account
@@ -22,7 +22,7 @@ commands:
         usage: /logout
     unregister:
         description: unregister your account
-        usage: /unregister password         
+        usage: /unregister password
     authme:
         description: AuthMe op commands
         usage: '/authme reload|register playername password|changepassword playername password|unregister playername|version'


### PR DESCRIPTION
…ng ProtocolLib.

Instead of clearing the inventory of players and storing it's contents in a file, we now prevent
the server from sending the inventory packet if the player is not logged in. The player will
see a empty inventory, but has still his items stored on the server. Therefore we don't
need to modify the player's inventory and we won't make any inventory corrupted.

Fixes Xephi/AuthMeReloaded#203,
Fixes Xephi/AuthMeReloaded#193,
Fixes Xephi/AuthMeReloaded#191,
Fixes Xephi/AuthMeReloaded#148

Remove dead code + Fix empty inventory on the unregister command

Fix NPE if ProtocolLib isn't enabled or installed