### PR TITLE
Attempt to fix dubious isUuidInstance in vAuthFileReader

### DIFF
--- a/src/main/java/fr/xephi/authme/converter/vAuthFileReader.java
+++ b/src/main/java/fr/xephi/authme/converter/vAuthFileReader.java
@@ -47,7 +47,7 @@ public class vAuthFileReader {
                 String name = line.split(": ")[0];
                 String password = line.split(": ")[1];
                 PlayerAuth auth;
-                if (isUUIDinstance(password)) {
+                if (isUuidInstance(password)) {
                     String pname;
                     try {
                         pname = Bukkit.getOfflinePlayer(UUID.fromString(name)).getName();
@@ -68,15 +68,8 @@ public class vAuthFileReader {
 
     }
 
-    /**
-     * Method isUUIDinstance.
-     * @param s String
-    
-     * @return boolean */
-    private boolean isUUIDinstance(String s) {
-        if (String.valueOf(s.charAt(8)).equalsIgnoreCase("-"))
-            return true;
-        return true;
+    private static boolean isUuidInstance(String s) {
+        return s.length() > 8 && s.charAt(8) == '-';
     }
 
     /**


### PR DESCRIPTION
@Xephi Please review if this is what was actually intended. The old implementation doesn't check for string length and awkwardly uses String#valueOf. However, I'm not certain if my interpretation of the logic is correct.

Note that besides possibly throwing an exception, the method always returned `true`. The second return statement was probably meant to be a false. Or is it the other way around?