### PR TITLE
Lower event priority of PlayerInteractEvent in order to notify other

### DIFF
--- a/src/main/java/fr/xephi/authme/listener/AuthMePlayerListener.java
+++ b/src/main/java/fr/xephi/authme/listener/AuthMePlayerListener.java
@@ -440,7 +440,7 @@ public class AuthMePlayerListener implements Listener {
      *
      * @param event PlayerInteractEvent
      */
-    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
     public void onPlayerInteract(PlayerInteractEvent event) {
         Player player = event.getPlayer();
         if (player == null || Utils.checkAuth(player))


### PR DESCRIPTION
plugins (e.g. ServerSigns) that this event is canceled. 

Fixes Xephi/AuthMeReloaded#283