### PR TITLE
Remove gamemode and flying switching

### DIFF
--- a/src/main/java/fr/xephi/authme/cache/backup/DataFileCache.java
+++ b/src/main/java/fr/xephi/authme/cache/backup/DataFileCache.java
@@ -6,19 +6,16 @@ public class DataFileCache {
 
     private final String group;
     private final boolean operator;
-    private final boolean flying;
 
     /**
      * Constructor for DataFileCache.
      *
      * @param group    String
      * @param operator boolean
-     * @param flying   boolean
      */
-    public DataFileCache(String group, boolean operator, boolean flying) {
+    public DataFileCache(String group, boolean operator) {
         this.group = group;
         this.operator = operator;
-        this.flying = flying;
     }
 
     /**
@@ -37,14 +34,5 @@ public class DataFileCache {
      */
     public boolean getOperator() {
         return operator;
-    }
-
-    /**
-     * Method isFlying.
-     *
-     * @return boolean
-     */
-    public boolean isFlying() {
-        return flying;
     }
 }

--- a/src/main/java/fr/xephi/authme/cache/backup/JsonCache.java
+++ b/src/main/java/fr/xephi/authme/cache/backup/JsonCache.java
@@ -154,7 +154,6 @@ public class JsonCache {
             JsonElement e;
             String group = null;
             boolean operator = false;
-            boolean flying = false;
 
             if ((e = jsonObject.get("group")) != null) {
                 group = e.getAsString();
@@ -162,11 +161,8 @@ public class JsonCache {
             if ((e = jsonObject.get("operator")) != null) {
                 operator = e.getAsBoolean();
             }
-            if ((e = jsonObject.get("flying")) != null) {
-                flying = e.getAsBoolean();
-            }
 
-            return new DataFileCache(group, operator, flying);
+            return new DataFileCache(group, operator);
         }
     }
 
@@ -187,7 +183,6 @@ public class JsonCache {
             JsonObject jsonObject = new JsonObject();
             jsonObject.addProperty("group", dataFileCache.getGroup());
             jsonObject.addProperty("operator", dataFileCache.getOperator());
-            jsonObject.addProperty("flying", dataFileCache.isFlying());
 
             return jsonObject;
         }

--- a/src/main/java/fr/xephi/authme/cache/limbo/LimboCache.java
+++ b/src/main/java/fr/xephi/authme/cache/limbo/LimboCache.java
@@ -4,11 +4,7 @@ import fr.xephi.authme.AuthMe;
 import fr.xephi.authme.ConsoleLogger;
 import fr.xephi.authme.cache.backup.DataFileCache;
 import fr.xephi.authme.cache.backup.JsonCache;
-import fr.xephi.authme.events.ResetInventoryEvent;
 import fr.xephi.authme.permission.PermissionsManager;
-import fr.xephi.authme.settings.Settings;
-import org.bukkit.Bukkit;
-import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
@@ -56,10 +52,8 @@ public class LimboCache {
     public void addLimboPlayer(Player player) {
         String name = player.getName().toLowerCase();
         Location loc = player.getLocation();
-        GameMode gameMode = player.getGameMode();
         boolean operator = false;
         String playerGroup = "";
-        boolean flying = false;
 
         // Get the permissions manager, and make sure it's valid
         PermissionsManager permsMan = this.plugin.getPermissionsManager();
@@ -72,35 +66,20 @@ public class LimboCache {
             if (cache != null) {
                 playerGroup = cache.getGroup();
                 operator = cache.getOperator();
-                flying = cache.isFlying();
             }
         } else {
             operator = player.isOp();
-            flying = player.isFlying();
 
             // Check whether groups are supported
             if (permsMan.hasGroupSupport())
                 playerGroup = permsMan.getPrimaryGroup(player);
         }
 
-        if (Settings.isForceSurvivalModeEnabled) {
-            if (Settings.isResetInventoryIfCreative && gameMode == GameMode.CREATIVE) {
-                ResetInventoryEvent event = new ResetInventoryEvent(player);
-                Bukkit.getServer().getPluginManager().callEvent(event);
-                if (!event.isCancelled()) {
-                    player.getInventory().clear();
-                    player.sendMessage("Your inventory has been cleaned!");
-                }
-            }
-            if (gameMode == GameMode.CREATIVE) {
-                flying = false;
-            }
-            gameMode = GameMode.SURVIVAL;
-        }
         if (player.isDead()) {
             loc = plugin.getSpawnLocation(player);
         }
-        cache.put(name, new LimboPlayer(name, loc, gameMode, operator, playerGroup, flying));
+
+        cache.put(name, new LimboPlayer(name, loc, operator, playerGroup));
     }
 
     /**

--- a/src/main/java/fr/xephi/authme/cache/limbo/LimboPlayer.java
+++ b/src/main/java/fr/xephi/authme/cache/limbo/LimboPlayer.java
@@ -1,6 +1,5 @@
 package fr.xephi.authme.cache.limbo;
 
-import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.scheduler.BukkitTask;
 
@@ -12,29 +11,23 @@ public class LimboPlayer {
     private Location loc = null;
     private BukkitTask timeoutTaskId = null;
     private BukkitTask messageTaskId = null;
-    private GameMode gameMode = GameMode.SURVIVAL;
     private boolean operator = false;
     private String group = "";
-    private boolean flying = false;
 
     /**
      * Constructor for LimboPlayer.
      *
      * @param name     String
      * @param loc      Location
-     * @param gameMode GameMode
      * @param operator boolean
      * @param group    String
-     * @param flying   boolean
      */
-    public LimboPlayer(String name, Location loc, GameMode gameMode,
-                       boolean operator, String group, boolean flying) {
+    public LimboPlayer(String name, Location loc,
+                       boolean operator, String group) {
         this.name = name;
         this.loc = loc;
-        this.gameMode = gameMode;
         this.operator = operator;
         this.group = group;
-        this.flying = flying;
     }
 
     /**
@@ -64,15 +57,6 @@ public class LimboPlayer {
      */
     public Location getLoc() {
         return loc;
-    }
-
-    /**
-     * Method getGameMode.
-     *
-     * @return GameMode
-     */
-    public GameMode getGameMode() {
-        return gameMode;
     }
 
     /**
@@ -148,14 +132,5 @@ public class LimboPlayer {
             timeoutTaskId.cancel();
         }
         timeoutTaskId = null;
-    }
-
-    /**
-     * Method isFlying.
-     *
-     * @return boolean
-     */
-    public boolean isFlying() {
-        return flying;
     }
 }

--- a/src/main/java/fr/xephi/authme/listener/AuthMePlayerListener.java
+++ b/src/main/java/fr/xephi/authme/listener/AuthMePlayerListener.java
@@ -18,7 +18,6 @@ import fr.xephi.authme.util.GeoLiteAPI;
 import fr.xephi.authme.util.Utils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -35,7 +34,6 @@ import org.bukkit.event.player.PlayerBedEnterEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerFishEvent;
-import org.bukkit.event.player.PlayerGameModeChangeEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
@@ -57,7 +55,6 @@ import static fr.xephi.authme.listener.ListenerService.shouldCancelEvent;
  */
 public class AuthMePlayerListener implements Listener {
 
-    public static final ConcurrentHashMap<String, GameMode> gameMode = new ConcurrentHashMap<>();
     public static final ConcurrentHashMap<String, String> joinMessage = new ConcurrentHashMap<>();
     public static final ConcurrentHashMap<String, Boolean> causeByAuthMe = new ConcurrentHashMap<>();
     public final AuthMe plugin;
@@ -491,25 +488,6 @@ public class AuthMePlayerListener implements Listener {
         if (spawn != null && spawn.getWorld() != null) {
             event.setRespawnLocation(spawn);
         }
-    }
-
-    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
-    public void onPlayerGameModeChange(PlayerGameModeChangeEvent event) {
-        if (!shouldCancelEvent(event)) {
-            return;
-        }
-
-        Player player = event.getPlayer();
-        if (plugin.getPermissionsManager().hasPermission(player, PlayerPermission.BYPASS_FORCE_SURVIVAL)) {
-            return;
-        }
-
-        String name = player.getName().toLowerCase();
-        if (causeByAuthMe.containsKey(name)) {
-            causeByAuthMe.remove(name);
-            return;
-        }
-        event.setCancelled(true);
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.NORMAL)

--- a/src/main/java/fr/xephi/authme/process/login/AsynchronousLogin.java
+++ b/src/main/java/fr/xephi/authme/process/login/AsynchronousLogin.java
@@ -7,7 +7,6 @@ import fr.xephi.authme.cache.auth.PlayerCache;
 import fr.xephi.authme.cache.limbo.LimboCache;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.events.AuthMeAsyncPreLoginEvent;
-import fr.xephi.authme.listener.AuthMePlayerListener;
 import fr.xephi.authme.permission.PlayerPermission;
 import fr.xephi.authme.security.PasswordSecurity;
 import fr.xephi.authme.security.RandomString;
@@ -204,9 +203,6 @@ public class AsynchronousLogin {
 
                     @Override
                     public void run() {
-                        if (AuthMePlayerListener.gameMode != null && AuthMePlayerListener.gameMode.containsKey(name)) {
-                            player.setGameMode(AuthMePlayerListener.gameMode.get(name));
-                        }
                         player.kickPlayer(m.retrieveSingle(MessageKey.WRONG_PASSWORD));
                     }
                 });

--- a/src/main/java/fr/xephi/authme/process/login/ProcessSyncronousPlayerLogin.java
+++ b/src/main/java/fr/xephi/authme/process/login/ProcessSyncronousPlayerLogin.java
@@ -67,16 +67,6 @@ public class ProcessSyncronousPlayerLogin implements Runnable {
         player.setOp(limbo.getOperator());
     }
 
-    protected void restoreFlyghtState() {
-        if (Settings.isForceSurvivalModeEnabled) {
-            player.setAllowFlight(false);
-            player.setFlying(false);
-            return;
-        }
-        player.setAllowFlight(limbo.isFlying());
-        player.setFlying(limbo.isFlying());
-    }
-
     protected void packQuitLocation() {
         Utils.packCoords(auth.getQuitLocX(), auth.getQuitLocY(), auth.getQuitLocZ(), auth.getWorld(), player);
     }
@@ -160,13 +150,6 @@ public class ProcessSyncronousPlayerLogin implements Runnable {
                 }
             }
 
-            if (Settings.isForceSurvivalModeEnabled && Settings.forceOnlyAfterLogin) {
-                Utils.forceGM(player);
-            } else {
-                player.setGameMode(limbo.getGameMode());
-            }
-
-            restoreFlyghtState();
             if (Settings.protectInventoryBeforeLogInEnabled) {
                 restoreInventory();
             }

--- a/src/main/java/fr/xephi/authme/process/logout/ProcessSyncronousPlayerLogout.java
+++ b/src/main/java/fr/xephi/authme/process/logout/ProcessSyncronousPlayerLogout.java
@@ -77,10 +77,6 @@ public class ProcessSyncronousPlayerLogout implements Runnable {
         if (Settings.applyBlindEffect)
             player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, Settings.getRegistrationTimeout * 20, 2));
         player.setOp(false);
-        if (!Settings.isMovementAllowed) {
-            player.setAllowFlight(true);
-            player.setFlying(true);
-        }
         // Player is now logout... Time to fire event !
         Bukkit.getServer().getPluginManager().callEvent(new LogoutEvent(player));
         if (Settings.bungee)

--- a/src/main/java/fr/xephi/authme/process/quit/AsynchronousQuit.java
+++ b/src/main/java/fr/xephi/authme/process/quit/AsynchronousQuit.java
@@ -6,7 +6,6 @@ import fr.xephi.authme.cache.auth.PlayerCache;
 import fr.xephi.authme.cache.limbo.LimboCache;
 import fr.xephi.authme.cache.limbo.LimboPlayer;
 import fr.xephi.authme.datasource.DataSource;
-import fr.xephi.authme.listener.AuthMePlayerListener;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.util.Utils;
 import org.bukkit.Bukkit;
@@ -23,7 +22,6 @@ public class AsynchronousQuit {
     protected final Player player;
     private final String name;
     private boolean isOp = false;
-    private boolean isFlying = false;
     private boolean needToChange = false;
     private boolean isKick = false;
 
@@ -69,7 +67,6 @@ public class AsynchronousQuit {
                 Utils.addNormal(player, limbo.getGroup());
             needToChange = true;
             isOp = limbo.getOperator();
-            isFlying = limbo.isFlying();
             if (limbo.getTimeoutTaskId() != null)
                 limbo.getTimeoutTaskId().cancel();
             if (limbo.getMessageTaskId() != null)
@@ -96,7 +93,6 @@ public class AsynchronousQuit {
             database.setUnlogged(name);
         }
 
-        AuthMePlayerListener.gameMode.remove(name);
-        Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, new ProcessSyncronousPlayerQuit(plugin, player, isOp, isFlying, needToChange));
+        Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, new ProcessSyncronousPlayerQuit(plugin, player, isOp, needToChange));
     }
 }

--- a/src/main/java/fr/xephi/authme/process/quit/ProcessSyncronousPlayerQuit.java
+++ b/src/main/java/fr/xephi/authme/process/quit/ProcessSyncronousPlayerQuit.java
@@ -1,8 +1,6 @@
 package fr.xephi.authme.process.quit;
 
 import fr.xephi.authme.AuthMe;
-import fr.xephi.authme.settings.Settings;
-import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 
 /**
@@ -12,7 +10,6 @@ public class ProcessSyncronousPlayerQuit implements Runnable {
     protected final AuthMe plugin;
     protected final Player player;
     protected final boolean isOp;
-    protected final boolean isFlying;
     protected final boolean needToChange;
 
     /**
@@ -21,16 +18,13 @@ public class ProcessSyncronousPlayerQuit implements Runnable {
      * @param plugin       AuthMe
      * @param player       Player
      * @param isOp         boolean
-     * @param isFlying     boolean
      * @param needToChange boolean
      */
     public ProcessSyncronousPlayerQuit(AuthMe plugin, Player player
-        , boolean isOp, boolean isFlying
-        , boolean needToChange) {
+        , boolean isOp, boolean needToChange) {
         this.plugin = plugin;
         this.player = player;
         this.isOp = isOp;
-        this.isFlying = isFlying;
         this.needToChange = needToChange;
     }
 
@@ -41,13 +35,8 @@ public class ProcessSyncronousPlayerQuit implements Runnable {
      */
     @Override
     public void run() {
-
         if (needToChange) {
             player.setOp(isOp);
-            if (player.getGameMode() != GameMode.CREATIVE && !Settings.isMovementAllowed) {
-                player.setAllowFlight(isFlying);
-                player.setFlying(isFlying);
-            }
         }
         try {
             player.getVehicle().eject();

--- a/src/main/java/fr/xephi/authme/process/register/ProcessSyncPasswordRegister.java
+++ b/src/main/java/fr/xephi/authme/process/register/ProcessSyncPasswordRegister.java
@@ -15,7 +15,6 @@ import fr.xephi.authme.task.MessageTask;
 import fr.xephi.authme.task.TimeoutTask;
 import fr.xephi.authme.util.Utils;
 import org.bukkit.Bukkit;
-import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitScheduler;
@@ -96,7 +95,6 @@ public class ProcessSyncPasswordRegister implements Runnable {
     public void run() {
         LimboPlayer limbo = LimboCache.getInstance().getLimboPlayer(name);
         if (limbo != null) {
-            player.setGameMode(limbo.getGameMode());
             Utils.teleportToSpawn(player);
 
             if (Settings.protectInventoryBeforeLogInEnabled && plugin.inventoryProtector != null) {
@@ -118,10 +116,6 @@ public class ProcessSyncPasswordRegister implements Runnable {
 
         if (!Settings.getmailAccount.isEmpty()) {
             m.send(player, MessageKey.ADD_EMAIL_MESSAGE);
-        }
-        if (player.getGameMode() != GameMode.CREATIVE && !Settings.isMovementAllowed) {
-            player.setAllowFlight(false);
-            player.setFlying(false);
         }
 
         if (Settings.applyBlindEffect) {

--- a/src/main/java/fr/xephi/authme/settings/Settings.java
+++ b/src/main/java/fr/xephi/authme/settings/Settings.java
@@ -65,15 +65,15 @@ public final class Settings {
         isSessionsEnabled, isAllowRestrictedIp,
         isMovementAllowed, isKickNonRegisteredEnabled,
         isForceSingleSessionEnabled, isForceSpawnLocOnJoinEnabled,
-        isSaveQuitLocationEnabled, isForceSurvivalModeEnabled,
-        isResetInventoryIfCreative, isCachingEnabled,
+        isSaveQuitLocationEnabled,
+        isCachingEnabled,
         isKickOnWrongPasswordEnabled, enablePasswordConfirmation,
         protectInventoryBeforeLogInEnabled, isBackupActivated,
         isBackupOnStart, isBackupOnStop, isStopEnabled, reloadSupport,
         rakamakUseIp, noConsoleSpam, removePassword, displayOtherAccounts,
         useCaptcha, emailRegistration, multiverse, bungee,
         banUnsafeIp, doubleEmailCheck, sessionExpireOnIpChange,
-        disableSocialSpy, forceOnlyAfterLogin, useEssentialsMotd, usePurge,
+        disableSocialSpy, useEssentialsMotd, usePurge,
         purgePlayerDat, purgeEssentialsFile, supportOldPassword,
         purgeLimitedCreative, purgeAntiXray, purgePermissions,
         enableProtection, enableAntiBot, recallEmail, useWelcomeMessage,
@@ -168,8 +168,6 @@ public final class Settings {
         isForceSingleSessionEnabled = configFile.getBoolean("settings.restrictions.ForceSingleSession", true);
         isForceSpawnLocOnJoinEnabled = configFile.getBoolean("settings.restrictions.ForceSpawnLocOnJoinEnabled", false);
         isSaveQuitLocationEnabled = configFile.getBoolean("settings.restrictions.SaveQuitLocation", false);
-        isForceSurvivalModeEnabled = configFile.getBoolean("settings.GameMode.ForceSurvivalMode", false);
-        isResetInventoryIfCreative = configFile.getBoolean("settings.GameMode.ResetInventoryIfCreative", false);
         getmaxRegPerIp = configFile.getInt("settings.restrictions.maxRegPerIp", 1);
         getPasswordHash = getPasswordHash();
         getUnloggedinGroup = configFile.getString("settings.security.unLoggedinGroup", "unLoggedInGroup");
@@ -255,7 +253,6 @@ public final class Settings {
         useLogging = configFile.getBoolean("Security.console.logConsole", false);
         disableSocialSpy = configFile.getBoolean("Hooks.disableSocialSpy", true);
         bCryptLog2Rounds = configFile.getInt("ExternalBoardOptions.bCryptLog2Round", 10);
-        forceOnlyAfterLogin = configFile.getBoolean("settings.GameMode.ForceOnlyAfterLogin", false);
         useEssentialsMotd = configFile.getBoolean("Hooks.useEssentialsMotd", false);
         usePurge = configFile.getBoolean("Purge.useAutoPurge", false);
         purgeDelay = configFile.getInt("Purge.daysBeforeRemovePlayer", 60);

--- a/src/main/java/fr/xephi/authme/util/Utils.java
+++ b/src/main/java/fr/xephi/authme/util/Utils.java
@@ -7,10 +7,9 @@ import fr.xephi.authme.cache.limbo.LimboCache;
 import fr.xephi.authme.cache.limbo.LimboPlayer;
 import fr.xephi.authme.events.AuthMeTeleportEvent;
 import fr.xephi.authme.permission.PermissionsManager;
-import fr.xephi.authme.permission.PlayerPermission;
 import fr.xephi.authme.settings.Settings;
+
 import org.bukkit.Bukkit;
-import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -193,17 +192,6 @@ public final class Utils {
                 }
             }
         });
-    }
-
-    /**
-     * Force the game mode of a player.
-     *
-     * @param player the player to modify.
-     */
-    public static void forceGM(Player player) {
-        if (!plugin.getPermissionsManager().hasPermission(player, PlayerPermission.BYPASS_FORCE_SURVIVAL)) {
-            player.setGameMode(GameMode.SURVIVAL);
-        }
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -152,14 +152,6 @@ settings:
         noTeleport: false
         # Regex syntax for allowed Chars in passwords.
         allowedPasswordCharacters: '[\x21-\x7E]*'
-    GameMode:
-        # ForceSurvivalMode to player when join ?
-        ForceSurvivalMode: false
-        # if player join with CreativeMode and ForceSurvivalMode: true
-        # inventory will be wipped
-        ResetInventoryIfCreative: false
-        # Do we need to force the survival mode ONLY after /login process?
-        ForceOnlyAfterLogin: false
     security:
         # minimum Length of password
         minPasswordLength: 5

--- a/src/test/java/fr/xephi/authme/util/UtilsTest.java
+++ b/src/test/java/fr/xephi/authme/util/UtilsTest.java
@@ -3,9 +3,8 @@ package fr.xephi.authme.util;
 import fr.xephi.authme.AuthMe;
 import fr.xephi.authme.ReflectionTestUtils;
 import fr.xephi.authme.permission.PermissionsManager;
-import fr.xephi.authme.permission.PlayerPermission;
 import fr.xephi.authme.settings.Settings;
-import org.bukkit.GameMode;
+
 import org.bukkit.entity.Player;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -48,35 +47,6 @@ public class UtilsTest {
 
         permissionsManagerMock = mock(PermissionsManager.class);
         when(authMeMock.getPermissionsManager()).thenReturn(permissionsManagerMock);
-    }
-
-    @Test
-    public void shouldForceSurvivalGameMode() {
-        // given
-        Player player = mock(Player.class);
-        given(permissionsManagerMock.hasPermission(player, PlayerPermission.BYPASS_FORCE_SURVIVAL)).willReturn(false);
-
-        // when
-        Utils.forceGM(player);
-
-        // then
-        verify(authMeMock).getPermissionsManager();
-        verify(player).setGameMode(GameMode.SURVIVAL);
-    }
-
-    @Test
-    public void shouldNotForceGameModeForUserWithBypassPermission() {
-        // given
-        Player player = mock(Player.class);
-        given(permissionsManagerMock.hasPermission(player, PlayerPermission.BYPASS_FORCE_SURVIVAL)).willReturn(true);
-
-        // when
-        Utils.forceGM(player);
-
-        // then
-        verify(authMeMock).getPermissionsManager();
-        verify(permissionsManagerMock).hasPermission(player, PlayerPermission.BYPASS_FORCE_SURVIVAL);
-        verify(player, never()).setGameMode(any(GameMode.class));
     }
 
     @Test


### PR DESCRIPTION
This pr removes the saving and restoring of gamemodes and flying states in order to fix inventory wipes and missing flying permissions.

This pr is open for discussion and testing.

- [x] Inventory is protected if the player isn't logged in.
- [x] Gamemodes keeps the same
- [x] Inventory cannot be changed until the player log in
- [x] Flying state keeps the same
- [x] Inventory is correctly separated by MultiInv if the gamemode changes.