### PR TITLE
#415 Move some permission nodes out of authme.player.*

### DIFF
--- a/src/main/java/fr/xephi/authme/AntiBot.java
+++ b/src/main/java/fr/xephi/authme/AntiBot.java
@@ -1,8 +1,8 @@
 package fr.xephi.authme;
 
-import fr.xephi.authme.permission.PlayerPermission;
 import fr.xephi.authme.output.MessageKey;
 import fr.xephi.authme.output.Messages;
+import fr.xephi.authme.permission.PlayerStatePermission;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.util.Wrapper;
 import org.bukkit.Bukkit;
@@ -73,7 +73,7 @@ public class AntiBot {
         if (antiBotStatus == AntiBotStatus.ACTIVE || antiBotStatus == AntiBotStatus.DISABLED) {
             return;
         }
-        if (plugin.getPermissionsManager().hasPermission(player, PlayerPermission.BYPASS_ANTIBOT)) {
+        if (plugin.getPermissionsManager().hasPermission(player, PlayerStatePermission.BYPASS_ANTIBOT)) {
             return;
         }
 

--- a/src/main/java/fr/xephi/authme/AuthMe.java
+++ b/src/main/java/fr/xephi/authme/AuthMe.java
@@ -14,6 +14,7 @@ import java.util.logging.Logger;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import fr.xephi.authme.datasource.DataSourceType;
+import fr.xephi.authme.permission.PlayerStatePermission;
 import fr.xephi.authme.settings.SettingsMigrationService;
 import org.apache.logging.log4j.LogManager;
 
@@ -68,7 +69,6 @@ import fr.xephi.authme.output.Log4JFilter;
 import fr.xephi.authme.output.MessageKey;
 import fr.xephi.authme.output.Messages;
 import fr.xephi.authme.permission.PermissionsManager;
-import fr.xephi.authme.permission.PlayerPermission;
 import fr.xephi.authme.process.Management;
 import fr.xephi.authme.security.HashAlgorithm;
 import fr.xephi.authme.security.PasswordSecurity;
@@ -707,7 +707,7 @@ public class AuthMe extends JavaPlugin {
     // Select the player to kick when a vip player joins the server when full
     public Player generateKickPlayer(Collection<? extends Player> collection) {
         for (Player player : collection) {
-            if (!getPermissionsManager().hasPermission(player, PlayerPermission.IS_VIP)) {
+            if (!getPermissionsManager().hasPermission(player, PlayerStatePermission.IS_VIP)) {
                 return player;
             }
         }

--- a/src/main/java/fr/xephi/authme/listener/AuthMePlayerListener.java
+++ b/src/main/java/fr/xephi/authme/listener/AuthMePlayerListener.java
@@ -13,6 +13,7 @@ import fr.xephi.authme.output.MessageKey;
 import fr.xephi.authme.output.Messages;
 import fr.xephi.authme.permission.PermissionsManager;
 import fr.xephi.authme.permission.PlayerPermission;
+import fr.xephi.authme.permission.PlayerStatePermission;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.util.GeoLiteAPI;
 import fr.xephi.authme.util.Utils;
@@ -222,7 +223,7 @@ public class AuthMePlayerListener implements Listener {
         }
 
         if (Settings.isForceSurvivalModeEnabled
-            && !player.hasPermission(PlayerPermission.BYPASS_FORCE_SURVIVAL.getNode())) {
+            && !player.hasPermission(PlayerStatePermission.BYPASS_FORCE_SURVIVAL.getNode())) {
             player.setGameMode(GameMode.SURVIVAL);
         }
 
@@ -295,7 +296,7 @@ public class AuthMePlayerListener implements Listener {
         PermissionsManager permsMan = plugin.getPermissionsManager();
 
         if (event.getResult() == PlayerLoginEvent.Result.KICK_FULL) {
-            if (permsMan.hasPermission(player, PlayerPermission.IS_VIP)) {
+            if (permsMan.hasPermission(player, PlayerStatePermission.IS_VIP)) {
                 int playersOnline = Utils.getOnlinePlayers().size();
                 if (playersOnline > plugin.getServer().getMaxPlayers()) {
                     event.allow();

--- a/src/main/java/fr/xephi/authme/permission/AdminPermission.java
+++ b/src/main/java/fr/xephi/authme/permission/AdminPermission.java
@@ -100,10 +100,10 @@ public enum AdminPermission implements PermissionNode {
      */
     RELOAD("authme.admin.reload"),
 
-	/**
-	 * Give access to all admin commands.
-	 */
-	ADMIN_ALL("authme.admin.*");
+    /**
+     * Permission to see the other accounts of the players that log in.
+     */
+    SEE_OTHER_ACCOUNTS("authme.admin.seeotheraccounts");
 
     /**
      * The permission node.
@@ -124,8 +124,4 @@ public enum AdminPermission implements PermissionNode {
         return node;
     }
 
-    @Override
-    public PermissionNode getWildcardNode() {
-        return ADMIN_ALL;
-    }
 }

--- a/src/main/java/fr/xephi/authme/permission/DefaultPermission.java
+++ b/src/main/java/fr/xephi/authme/permission/DefaultPermission.java
@@ -28,7 +28,7 @@ public enum DefaultPermission {
     /**
      *  Return the textual representation.
      *  
-     *  @return String
+     *  @return The textual representation
      */
     public String getTitle() {
         return title;

--- a/src/main/java/fr/xephi/authme/permission/PermissionNode.java
+++ b/src/main/java/fr/xephi/authme/permission/PermissionNode.java
@@ -12,11 +12,4 @@ public interface PermissionNode {
      */
     String getNode();
 
-    /**
-     * Return the wildcard node that also grants the permission.
-     *
-     * @return The wildcard permission node (e.g. "authme.player.*")
-     */
-    PermissionNode getWildcardNode();
-
 }

--- a/src/main/java/fr/xephi/authme/permission/PermissionsManager.java
+++ b/src/main/java/fr/xephi/authme/permission/PermissionsManager.java
@@ -299,7 +299,6 @@ public class PermissionsManager implements PermissionsService {
 
         Player player = (Player) sender;
         return hasPermission(player, permissionNode.getNode(), def);
-        //    || hasPermission(player, permissionNode.getWildcardNode().getNode(), def);
     }
 
     public boolean hasPermission(Player player, Iterable<PermissionNode> nodes, boolean def) {

--- a/src/main/java/fr/xephi/authme/permission/PlayerPermission.java
+++ b/src/main/java/fr/xephi/authme/permission/PlayerPermission.java
@@ -6,16 +6,6 @@ package fr.xephi.authme.permission;
 public enum PlayerPermission implements PermissionNode {
 
     /**
-     * Permission node to bypass AntiBot protection.
-     */
-    BYPASS_ANTIBOT("authme.player.bypassantibot"),
-
-    /**
-     * Permission node to identify VIP users.
-     */
-    IS_VIP("authme.player.vip"),
-
-    /**
      * Command permission to login.
      */
     LOGIN("authme.player.login"),
@@ -65,26 +55,6 @@ public enum PlayerPermission implements PermissionNode {
      */
     CAN_LOGIN_BE_FORCED("authme.player.canbeforced"),
 
-    /**
-     * Permission for users to bypass force-survival mode.
-     */
-    BYPASS_FORCE_SURVIVAL("authme.player.bypassforcesurvival"),
-
-    /**
-     * Permission for users to allow two accounts.
-     */
-    ALLOW_MULTIPLE_ACCOUNTS("authme.player.allow2accounts"),
-
-    /**
-     * Permission for user to see other accounts.
-     */
-    SEE_OTHER_ACCOUNTS("authme.player.seeotheraccounts"),
-
-	/**
-	 * Permission to use all player (non-admin) commands.
-	 */
-	PLAYER_ALL("authme.player.*"),
-
 	/**
 	 * Permission to use to see own other accounts.
 	 */
@@ -109,8 +79,4 @@ public enum PlayerPermission implements PermissionNode {
         return node;
     }
 
-    @Override
-    public PermissionNode getWildcardNode() {
-        return PLAYER_ALL;
-    }
 }

--- a/src/main/java/fr/xephi/authme/permission/PlayerStatePermission.java
+++ b/src/main/java/fr/xephi/authme/permission/PlayerStatePermission.java
@@ -1,0 +1,47 @@
+package fr.xephi.authme.permission;
+
+/**
+ * Permission nodes that give a player a status (e.g. VIP)
+ * or grant them more freedom (e.g. less restrictions).
+ */
+public enum PlayerStatePermission implements PermissionNode {
+
+    /**
+     * Permission node to bypass AntiBot protection.
+     */
+    BYPASS_ANTIBOT("authme.bypassantibot"),
+
+    /**
+     * Permission for users to bypass force-survival mode.
+     */
+    BYPASS_FORCE_SURVIVAL("authme.bypassforcesurvival"),
+
+    /**
+     * Permission node to identify VIP users.
+     */
+    IS_VIP("authme.vip"),
+
+    /**
+     * Permission to be able to register multiple accounts.
+     */
+    ALLOW_MULTIPLE_ACCOUNTS("authme.allowmultipleaccounts");
+
+    /**
+     * The permission node.
+     */
+    private String node;
+
+    /**
+     * Constructor.
+     *
+     * @param node Permission node.
+     */
+    PlayerStatePermission(String node) {
+        this.node = node;
+    }
+
+    @Override
+    public String getNode() {
+        return node;
+    }
+}

--- a/src/main/java/fr/xephi/authme/process/join/AsynchronousJoin.java
+++ b/src/main/java/fr/xephi/authme/process/join/AsynchronousJoin.java
@@ -13,6 +13,7 @@ import fr.xephi.authme.listener.AuthMePlayerListener;
 import fr.xephi.authme.output.MessageKey;
 import fr.xephi.authme.output.Messages;
 import fr.xephi.authme.permission.PlayerPermission;
+import fr.xephi.authme.permission.PlayerStatePermission;
 import fr.xephi.authme.settings.Settings;
 import fr.xephi.authme.settings.Spawn;
 import fr.xephi.authme.task.MessageTask;
@@ -78,7 +79,7 @@ public class AsynchronousJoin {
             return;
         }
         if (Settings.getMaxJoinPerIp > 0
-            && !plugin.getPermissionsManager().hasPermission(player, PlayerPermission.ALLOW_MULTIPLE_ACCOUNTS)
+            && !plugin.getPermissionsManager().hasPermission(player, PlayerStatePermission.ALLOW_MULTIPLE_ACCOUNTS)
             && !ip.equalsIgnoreCase("127.0.0.1")
             && !ip.equalsIgnoreCase("localhost")
             && plugin.hasJoinedIp(player.getName(), ip)) {

--- a/src/main/java/fr/xephi/authme/process/login/AsynchronousLogin.java
+++ b/src/main/java/fr/xephi/authme/process/login/AsynchronousLogin.java
@@ -7,7 +7,9 @@ import fr.xephi.authme.cache.auth.PlayerCache;
 import fr.xephi.authme.cache.limbo.LimboCache;
 import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.events.AuthMeAsyncPreLoginEvent;
+import fr.xephi.authme.permission.AdminPermission;
 import fr.xephi.authme.permission.PlayerPermission;
+import fr.xephi.authme.permission.PlayerStatePermission;
 import fr.xephi.authme.security.RandomString;
 import fr.xephi.authme.output.MessageKey;
 import fr.xephi.authme.output.Messages;
@@ -117,7 +119,7 @@ public class AsynchronousLogin {
         }
 
         if (Settings.getMaxLoginPerIp > 0
-            && !plugin.getPermissionsManager().hasPermission(player, PlayerPermission.ALLOW_MULTIPLE_ACCOUNTS)
+            && !plugin.getPermissionsManager().hasPermission(player, PlayerStatePermission.ALLOW_MULTIPLE_ACCOUNTS)
             && !ip.equalsIgnoreCase("127.0.0.1") && !ip.equalsIgnoreCase("localhost")) {
             if (plugin.isLoggedIp(name, ip)) {
                 m.send(player, MessageKey.ALREADY_LOGGED_IN_ERROR);
@@ -230,7 +232,7 @@ public class AsynchronousLogin {
         }
         String message = "[AuthMe] " + StringUtils.join(", ", auths) + ".";
         for (Player player : Utils.getOnlinePlayers()) {
-            if (plugin.getPermissionsManager().hasPermission(player, PlayerPermission.SEE_OTHER_ACCOUNTS)
+            if (plugin.getPermissionsManager().hasPermission(player, AdminPermission.SEE_OTHER_ACCOUNTS)
             		|| (player.getName().equals(this.player.getName())
             				&& plugin.getPermissionsManager().hasPermission(player, PlayerPermission.SEE_OWN_ACCOUNTS))) {
                 player.sendMessage("[AuthMe] The player " + auth.getNickname() + " has " + auths.size() + " accounts");

--- a/src/main/java/fr/xephi/authme/process/register/AsyncRegister.java
+++ b/src/main/java/fr/xephi/authme/process/register/AsyncRegister.java
@@ -8,6 +8,7 @@ import fr.xephi.authme.datasource.DataSource;
 import fr.xephi.authme.output.MessageKey;
 import fr.xephi.authme.output.Messages;
 import fr.xephi.authme.permission.PlayerPermission;
+import fr.xephi.authme.permission.PlayerStatePermission;
 import fr.xephi.authme.security.HashAlgorithm;
 import fr.xephi.authme.security.crypts.HashedPassword;
 import fr.xephi.authme.security.crypts.TwoFactor;
@@ -75,7 +76,7 @@ public class AsyncRegister {
             m.send(player, MessageKey.NAME_ALREADY_REGISTERED);
             return false;
         } else if (Settings.getmaxRegPerIp > 0
-            && !plugin.getPermissionsManager().hasPermission(player, PlayerPermission.ALLOW_MULTIPLE_ACCOUNTS)
+            && !plugin.getPermissionsManager().hasPermission(player, PlayerStatePermission.ALLOW_MULTIPLE_ACCOUNTS)
             && !ip.equalsIgnoreCase("127.0.0.1")
             && !ip.equalsIgnoreCase("localhost")
             && database.getAllAuthsByIp(ip).size() >= Settings.getmaxRegPerIp) {
@@ -97,7 +98,7 @@ public class AsyncRegister {
 
     private void emailRegister() {
         if (Settings.getmaxRegPerEmail > 0
-            && !plugin.getPermissionsManager().hasPermission(player, PlayerPermission.ALLOW_MULTIPLE_ACCOUNTS)
+            && !plugin.getPermissionsManager().hasPermission(player, PlayerStatePermission.ALLOW_MULTIPLE_ACCOUNTS)
             && database.getAllAuthsByEmail(email).size() >= Settings.getmaxRegPerEmail) {
             m.send(player, MessageKey.MAX_REGISTER_EXCEEDED);
             return;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -14,32 +14,32 @@ softdepend:
     - EssentialsSpawn
     - ProtocolLib
 commands:
+    authme:
+        description: AuthMe op commands
+        usage: '/authme reload|register playername password|changepassword playername password|unregister playername|version'
     register:
         description: Register an account
-        usage: /register password confirmpassword
-        aliases: reg
+        usage: /register <password> <confirmpassword>
+        aliases: [reg]
     login:
-        description: Login into a account
-        usage: /login password
-        aliases: l
+        description: Login command
+        usage: /login <password>
+        aliases: [l,log]
     changepassword:
-        description: Change password of a account
-        usage: /changepassword oldPassword newPassword
+        description: Change password of an account
+        usage: /changepassword <oldPassword> <newPassword>
     logout:
         description: Logout
         usage: /logout
     unregister:
-        description: unregister your account
-        usage: /unregister password
-    authme:
-        description: AuthMe op commands
-        usage: '/authme reload|register playername password|changepassword playername password|unregister playername|version'
+        description: Unregister your account
+        usage: /unregister <password>
     email:
         description: Add Email or recover password
         usage: '/email add your@email.com your@email.com|change oldEmail newEmail|recovery your@email.com'
     captcha:
-        description: Captcha
-        usage: /captcha theCaptcha
+        description: Captcha command
+        usage: /captcha <code>
     converter:
         description: Converter from different other auth plugins
         usage: /converter <datatype>
@@ -114,6 +114,9 @@ permissions:
     authme.admin.purgebannedplayers:
         description: Administrator command to purge all data associated with banned players.
         default: op
+    authme.admin.seeotheraccounts:
+        description: Permission for user to see other accounts.
+        default: op
     authme.admin.switchantibot:
         description: Administrator command to toggle the AntiBot protection status.
         default: op
@@ -126,9 +129,6 @@ permissions:
     authme.player.*:
         description: Permission to use all player (non-admin) commands.
         children:
-            authme.player.allow2accounts: true
-            authme.player.bypassantibot: true
-            authme.player.bypassforcesurvival: true
             authme.player.canbeforced: true
             authme.player.captcha: true
             authme.player.changepassword: true
@@ -138,16 +138,15 @@ permissions:
             authme.player.login: true
             authme.player.logout: true
             authme.player.register: true
-            authme.player.seeotheraccounts: true
             authme.player.unregister: true
-            authme.player.vip: true
             authme.player.seeownaccounts: true
-    authme.player.bypassantibot:
-        description: Permission node to bypass AntiBot protection.
+    authme.player.email:
+        description: Gives access to player email commands
         default: false
-    authme.player.vip:
-        description: Permission node to identify VIP users.
-        default: false
+        children:
+            authme.player.email.add: true
+            authme.player.email.change: true
+            authme.player.email.recover: true
     authme.player.login:
         description: Command permission to login.
         default: true
@@ -178,15 +177,15 @@ permissions:
     authme.player.canbeforced:
         description: Permission for users a login can be forced to.
         default: false
-    authme.player.bypassforcesurvival:
-        description: Permission for users to bypass force-survival mode.
+    authme.vip:
+        description: Allow vip slot when the server is full
         default: false
-    authme.player.allow2accounts:
-        description: Permission for users to allow two accounts.
+    authme.bypassantibot:
+        description: Bypass the AntiBot check
         default: false
-    authme.player.seeotheraccounts:
-        description: Permission for user to see other accounts.
+    authme.allowmultipleaccounts:
+        description: Allow more accounts for same ip
         default: false
-    authme.player.seeownaccounts:
-        description: Permission for user to see own other accounts.
+    authme.bypassforcesurvival:
+        description: Bypass all ForceSurvival features
         default: false

--- a/src/test/java/fr/xephi/authme/permission/PlayerStatePermissionTest.java
+++ b/src/test/java/fr/xephi/authme/permission/PlayerStatePermissionTest.java
@@ -1,0 +1,56 @@
+package fr.xephi.authme.permission;
+
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.google.common.collect.Sets.newHashSet;
+import static org.junit.Assert.fail;
+
+/**
+ * Test for {@link PlayerStatePermission}.
+ */
+public class PlayerStatePermissionTest {
+
+    @Test
+    public void shouldStartWithAuthMeAdminPrefix() {
+        // given
+        String requiredPrefix = "authme.";
+        Set<String> forbiddenPrefixes = newHashSet("authme.player", "authme.admin");
+
+        // when/then
+        for (PlayerStatePermission permission : PlayerStatePermission.values()) {
+            if (!permission.getNode().startsWith(requiredPrefix)) {
+                fail("The permission '" + permission + "' does not start with the required prefix '"
+                    + requiredPrefix + "'");
+            } else if (hasAnyPrefix(permission.getNode(), forbiddenPrefixes)) {
+                fail("The permission '" + permission + "' should not start with any of " + forbiddenPrefixes);
+            }
+        }
+    }
+
+    @Test
+    public void shouldHaveUniqueNodes() {
+        // given
+        Set<String> nodes = new HashSet<>();
+
+        // when/then
+        for (PlayerStatePermission permission : PlayerStatePermission.values()) {
+            if (nodes.contains(permission.getNode())) {
+                fail("More than one enum value defines the node '" + permission.getNode() + "'");
+            }
+            nodes.add(permission.getNode());
+        }
+    }
+
+    private static boolean hasAnyPrefix(String node, Set<String> prefixes) {
+        for (String prefix : prefixes) {
+            if (node.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/tools/docs/permission_nodes.md
+++ b/src/tools/docs/permission_nodes.md
@@ -1,5 +1,5 @@
 <!-- AUTO-GENERATED FILE! Do not edit this directly -->
-<!-- File auto-generated on Sat Dec 05 21:18:25 CET 2015. See permissions/permission_nodes.tpl.md -->
+<!-- File auto-generated on Sun Feb 14 14:11:28 CET 2016. See permissions/permission_nodes.tpl.md -->
 
 ## AuthMe Permission Nodes
 The following are the permission nodes that are currently supported by the latest dev builds.
@@ -19,15 +19,16 @@ The following are the permission nodes that are currently supported by the lates
 - **authme.admin.purgelastpos** – Administrator command to purge the last position of a user.
 - **authme.admin.register** – Administrator command to register a new user.
 - **authme.admin.reload** – Administrator command to reload the plugin configuration.
+- **authme.admin.seeotheraccounts** – Permission to see the other accounts of the players that log in.
 - **authme.admin.setfirstspawn** – Administrator command to set the first AuthMe spawn.
 - **authme.admin.setspawn** – Administrator command to set the AuthMe spawn.
 - **authme.admin.spawn** – Administrator command to teleport to the AuthMe spawn.
 - **authme.admin.switchantibot** – Administrator command to toggle the AntiBot protection status.
 - **authme.admin.unregister** – Administrator command to unregister an existing user.
+- **authme.allowmultipleaccounts** – Permission to be able to register multiple accounts.
+- **authme.bypassantibot** – Permission node to bypass AntiBot protection.
+- **authme.bypassforcesurvival** – Permission for users to bypass force-survival mode.
 - **authme.player.*** – Permission to use all player (non-admin) commands.
-- **authme.player.allow2accounts** – Permission for users to allow two accounts.
-- **authme.player.bypassantibot** – Permission node to bypass AntiBot protection.
-- **authme.player.bypassforcesurvival** – Permission for users to bypass force-survival mode.
 - **authme.player.canbeforced** – Permission for users a login can be forced to.
 - **authme.player.captcha** – Command permission to use captcha.
 - **authme.player.changepassword** – Command permission to change the password.
@@ -37,7 +38,7 @@ The following are the permission nodes that are currently supported by the lates
 - **authme.player.login** – Command permission to login.
 - **authme.player.logout** – Command permission to logout.
 - **authme.player.register** – Command permission to register.
-- **authme.player.seeotheraccounts** – Permission for user to see other accounts.
+- **authme.player.seeownaccounts** – Permission to use to see own other accounts.
 - **authme.player.unregister** – Command permission to unregister.
-- **authme.player.vip** – Permission node to identify VIP users.
+- **authme.vip** – Permission node to identify VIP users.
 

--- a/src/tools/permissions/PermissionNodesGatherer.java
+++ b/src/tools/permissions/PermissionNodesGatherer.java
@@ -3,6 +3,7 @@ package permissions;
 import fr.xephi.authme.permission.AdminPermission;
 import fr.xephi.authme.permission.PermissionNode;
 import fr.xephi.authme.permission.PlayerPermission;
+import fr.xephi.authme.permission.PlayerStatePermission;
 import utils.FileUtils;
 import utils.ToolsConstants;
 
@@ -53,8 +54,13 @@ public class PermissionNodesGatherer {
      */
     public Map<String, String> gatherNodesWithJavaDoc() {
         Map<String, String> result = new TreeMap<>();
+        result.put("authme.admin.*", "Give access to all admin commands.");
+        result.put("authme.player.*", "Permission to use all player (non-admin) commands.");
+        // TODO ljacqu 20160109: Add authme.player.email manual description?
+
         addDescriptionsForClass(PlayerPermission.class, result);
         addDescriptionsForClass(AdminPermission.class, result);
+        addDescriptionsForClass(PlayerStatePermission.class, result);
         return result;
     }
 
@@ -89,7 +95,7 @@ public class PermissionNodesGatherer {
      * Return the Java source code for the given implementation of {@link PermissionNode}.
      *
      * @param clazz The clazz to the get the source for
-     * @param <T> The concrete class
+     * @param <T> The concrete type
      * @return Source code of the file
      */
     private static <T extends Enum<T> & PermissionNode> String getSourceForClass(Class<T> clazz) {


### PR DESCRIPTION
This PR has essentially the same changes as commit e33a04b35fc2f099b062a0c4e8577f6222a24ea3, which is on the old 415-perms-rework branch. It was easier to do the changes again than to merge master into the branch.

Renamed permission nodes:
```
authme.player.allow2accounts      -> authme.allowmultipleaccounts
authme.player.bypassantibot       -> authme.bypassantibot
authme.player.bypassforcesurvival -> authme.bypassforcesurvival
authme.player.seeotheraccounts    -> authme.admin.seeotheraccounts
authme.player.vip                 -> authme.vip
```

Please review and make any changes you're not happy with (e.g. if you have a better name for `PlayerStatePermission`).

Once the PR is merged I'll add an entry to the breaking changes Wiki page.