### PR TITLE
Add isPermissionsSystem method to PermissionsSystemType enum - fixes …

### DIFF
--- a/src/main/java/fr/xephi/authme/permission/PermissionsManager.java
+++ b/src/main/java/fr/xephi/authme/permission/PermissionsManager.java
@@ -224,11 +224,12 @@ public class PermissionsManager implements PermissionsService {
         String pluginName = plugin.getName();
 
         // Check if any known permissions system is enabling
-        if (pluginName.equals("PermissionsEx") || pluginName.equals("PermissionsBukkit") ||
-            pluginName.equals("bPermissions") || pluginName.equals("GroupManager") ||
-            pluginName.equals("zPermissions") || pluginName.equals("Vault")) {
-            ConsoleLogger.info(pluginName + " plugin enabled, dynamically updating permissions hooks!");
-            setup();
+        for (PermissionsSystemType permissionsSystemType : PermissionsSystemType.values()) {
+            if (permissionsSystemType.isPermissionSystem(pluginName)) {
+                ConsoleLogger.info(pluginName + " plugin enabled, dynamically updating permissions hooks!");
+                setup();
+                break;
+            }
         }
     }
 
@@ -243,11 +244,12 @@ public class PermissionsManager implements PermissionsService {
         String pluginName = plugin.getName();
 
         // Is the WorldGuard plugin disabled
-        if (pluginName.equals("PermissionsEx") || pluginName.equals("PermissionsBukkit") ||
-            pluginName.equals("bPermissions") || pluginName.equals("GroupManager") ||
-            pluginName.equals("zPermissions") || pluginName.equals("Vault")) {
-            ConsoleLogger.info(pluginName + " plugin disabled, updating hooks!");
-            setup();
+        for (PermissionsSystemType permissionsSystemType : PermissionsSystemType.values()) {
+            if (permissionsSystemType.isPermissionSystem(pluginName)) {
+                ConsoleLogger.info(pluginName + " plugin disabled, updating hooks!");
+                setup();
+                break;
+            }
         }
     }
 

--- a/src/main/java/fr/xephi/authme/permission/PermissionsSystemType.java
+++ b/src/main/java/fr/xephi/authme/permission/PermissionsSystemType.java
@@ -83,4 +83,14 @@ public enum PermissionsSystemType {
     public String toString() {
         return getName();
     }
+
+    /**
+     * Check if a given plugin is a permissions system.
+     *
+     * @param name The name of the plugin to check.
+     * @return If the plugin is a valid permissions system.
+     */
+    public boolean isPermissionSystem(String name) {
+        return name.equals(pluginName);
+    }
 }


### PR DESCRIPTION
…#612

The added method checks to see if the given plugin name matches the pluginName field of the enum.
When a plugin is enabled or disabled, loop through all enum values and see if it matches one of them by calling the method.

Any feedback or criticism would be much appreciated!