### PR TITLE
Add a lowercase String list property - fixes #602

### DIFF
--- a/src/main/java/fr/xephi/authme/settings/domain/Property.java
+++ b/src/main/java/fr/xephi/authme/settings/domain/Property.java
@@ -3,6 +3,7 @@ package fr.xephi.authme.settings.domain;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.yaml.snakeyaml.Yaml;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -31,6 +32,17 @@ public abstract class Property<T> {
     public static Property<List<String>> newListProperty(String path, String... defaultValues) {
         // does not have the same name as not to clash with #newProperty(String, String)
         return new StringListProperty(path, defaultValues);
+    }
+
+    /**
+     * Create a new String list property where all values are lowercase.
+     *
+     * @param path The property's path
+     * @param defaultValues The items in the default list
+     * @return The created list property
+     */
+    public static Property<List<String>> newLowercaseListProperty(String path, String... defaultValues) {
+        return new LowercaseStringListProperty(path, defaultValues);
     }
 
     /**
@@ -165,7 +177,7 @@ public abstract class Property<T> {
     /**
      * String list property.
      */
-    private static final class StringListProperty extends Property<List<String>> {
+    private static class StringListProperty extends Property<List<String>> {
 
         public StringListProperty(String path, String[] defaultValues) {
             super(path, Arrays.asList(defaultValues));
@@ -196,4 +208,28 @@ public abstract class Property<T> {
         }
     }
 
+    /**
+     * Lowercase String list property.
+     */
+    private static final class LowercaseStringListProperty extends StringListProperty {
+
+        public LowercaseStringListProperty(String path, String[] defaultValues) {
+            super(path, defaultValues);
+        }
+
+        @Override
+        public List<String> getFromFile(FileConfiguration configuration) {
+            if (!configuration.isList(getPath())) {
+                return getDefaultValue();
+            }
+
+            // make sure all elements are lowercase
+            List<String> lowercaseList = new ArrayList<>();
+            for (String element : configuration.getStringList(getPath())) {
+                lowercaseList.add(element.toLowerCase());
+            }
+
+            return lowercaseList;
+        }
+    }
 }

--- a/src/main/java/fr/xephi/authme/settings/properties/RestrictionSettings.java
+++ b/src/main/java/fr/xephi/authme/settings/properties/RestrictionSettings.java
@@ -7,6 +7,7 @@ import fr.xephi.authme.settings.domain.SettingsClass;
 import java.util.List;
 
 import static fr.xephi.authme.settings.domain.Property.newListProperty;
+import static fr.xephi.authme.settings.domain.Property.newLowercaseListProperty;
 import static fr.xephi.authme.settings.domain.Property.newProperty;
 
 public class RestrictionSettings implements SettingsClass {
@@ -30,7 +31,7 @@ public class RestrictionSettings implements SettingsClass {
 
     @Comment("Allowed commands for unauthenticated players")
     public static final Property<List<String>> ALLOW_COMMANDS =
-        newListProperty("settings.restrictions.allowCommands",
+        newLowercaseListProperty("settings.restrictions.allowCommands",
             "/login", "/register", "/l", "/reg", "/email", "/captcha");
 
     @Comment({
@@ -87,7 +88,7 @@ public class RestrictionSettings implements SettingsClass {
         "    AllowedRestrictedUser:",
         "    - playername;127.0.0.1"})
     public static final Property<List<String>> ALLOWED_RESTRICTED_USERS =
-        newListProperty("settings.restrictions.AllowedRestrictedUser");
+        newLowercaseListProperty("settings.restrictions.AllowedRestrictedUser");
 
     @Comment("Should unregistered players be kicked immediately?")
     public static final Property<Boolean> KICK_NON_REGISTERED =
@@ -194,7 +195,7 @@ public class RestrictionSettings implements SettingsClass {
         "It is case-sensitive!"
     })
     public static final Property<List<String>> UNRESTRICTED_NAMES =
-        newListProperty("settings.unrestrictions.UnrestrictedName");
+        newLowercaseListProperty("settings.unrestrictions.UnrestrictedName");
 
 
     private RestrictionSettings() {

--- a/src/main/java/fr/xephi/authme/settings/properties/SecuritySettings.java
+++ b/src/main/java/fr/xephi/authme/settings/properties/SecuritySettings.java
@@ -8,6 +8,7 @@ import fr.xephi.authme.settings.domain.SettingsClass;
 import java.util.List;
 
 import static fr.xephi.authme.settings.domain.Property.newListProperty;
+import static fr.xephi.authme.settings.domain.Property.newLowercaseListProperty;
 import static fr.xephi.authme.settings.domain.Property.newProperty;
 
 public class SecuritySettings implements SettingsClass {
@@ -98,7 +99,7 @@ public class SecuritySettings implements SettingsClass {
         "- '123456'",
         "- 'password'"})
     public static final Property<List<String>> UNSAFE_PASSWORDS =
-        newListProperty("settings.security.unsafePasswords", "123456", "password", "qwerty", "12345", "54321");
+        newLowercaseListProperty("settings.security.unsafePasswords", "123456", "password", "qwerty", "12345", "54321");
 
     private SecuritySettings() {
     }

--- a/src/test/java/fr/xephi/authme/settings/domain/PropertyTest.java
+++ b/src/test/java/fr/xephi/authme/settings/domain/PropertyTest.java
@@ -38,6 +38,9 @@ public class PropertyTest {
         when(configuration.isList("list.path.test")).thenReturn(true);
         when(configuration.getStringList("list.path.test")).thenReturn(Arrays.asList("test1", "Test2", "3rd test"));
         when(configuration.isList("list.path.wrong")).thenReturn(false);
+        when(configuration.isList("lowercaselist.path.test")).thenReturn(true);
+        when(configuration.getStringList("lowercaselist.path.test")).thenReturn(Arrays.asList("test1", "Test2", "3rd test"));
+        when(configuration.isList("lowercaselist.path.wrong")).thenReturn(false);
     }
 
     /* Boolean */
@@ -141,4 +144,29 @@ public class PropertyTest {
         assertThat(result, contains("default", "list", "elements"));
     }
 
+    /* Lowercase String list */
+    @Test
+    public void shouldGetLowercaseStringListValue() {
+        // given
+        Property<List<String>> property = Property.newLowercaseListProperty("lowercaselist.path.test", "1", "b");
+
+        // when
+        List<String> result = property.getFromFile(configuration);
+
+        // then
+        assertThat(result, contains("test1", "test2", "3rd test"));
+    }
+
+    @Test
+    public void shouldGetLowercaseStringListDefault() {
+        // given
+        Property<List<String>> property =
+            Property.newLowercaseListProperty("lowercaselist.path.wrong", "default", "list", "elements");
+
+        // when
+        List<String> result = property.getFromFile(configuration);
+
+        // then
+        assertThat(result, contains("default", "list", "elements"));
+    }
 }


### PR DESCRIPTION
Added a new property that extends `StringListProperty` inside of `Property`.
This new property overrides the `getFromFile()` method to convert all elements in the list from the configuration (if the path given is a valid list) to lowercase Strings. I assumed that default values being passed to this property would already be lowercase; if this is incorrect, it will be minor to fix that.

The four settings listed in the original issue have been changed to use the new `LowercaseStringListProperty`.

Tests have been added to ensure that the property's method does convert elements to lowercase. These tests pass on my local branch.