### PR TITLE
#565 Allow to skip extended encryption methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <!-- Output properties -->
         <project.outputName>AuthMe</project.outputName>
         <project.buildNumber>CUSTOM</project.buildNumber>
+        <project.skipExtendedHashTests>false</project.skipExtendedHashTests>
         <project.versionCode>${project.version}-b${project.buildNumber}</project.versionCode>
         <project.finalName>${project.outputName}-${project.version}</project.finalName>
 
@@ -79,6 +80,17 @@
             </activation>
             <properties>
                 <project.buildNumber>${env.BUILD_NUMBER}</project.buildNumber>
+            </properties>
+        </profile>
+        <profile>
+            <id>skipLongHashTests</id>
+            <activation>
+                <property>
+                    <name>skipLongHashTests</name>
+                </property>
+            </activation>
+            <properties>
+                <project.skipExtendedHashTests>true</project.skipExtendedHashTests>
             </properties>
         </profile>
     </profiles>
@@ -124,6 +136,9 @@
                 <version>2.19.1</version>
                 <configuration>
                     <argLine>-Dfile.encoding=${project.build.sourceEncoding} @{argLine}</argLine>
+                    <systemPropertyVariables>
+                        <project.skipExtendedHashTests>${project.skipExtendedHashTests}</project.skipExtendedHashTests>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <!-- Libs Shading and Relocation -->

--- a/src/test/java/fr/xephi/authme/security/crypts/AbstractEncryptionMethodTest.java
+++ b/src/test/java/fr/xephi/authme/security/crypts/AbstractEncryptionMethodTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
 
 /**
  * Test for implementations of {@link EncryptionMethod}.
@@ -35,6 +36,14 @@ public abstract class AbstractEncryptionMethodTest {
     private static final String[] BOGUS_HASHES = {"", "test", "$t$test$", "$SHA$Test$$$$", "$$$$$",
         "asdfg:hjkl", "::test", "~#$#~~~#$#~", "d41d8cd98f00b204e9800998ecf427e",
         "$2y$7a$da641e404b982ed" };
+
+    /**
+     * Certain hash algorithms are slow by design, which has a considerable effect on these unit tests.
+     * Setting the property below to "true" will reduce the checks in these unit tests as to offer fast,
+     * partial tests during development.
+     */
+    private static final boolean SKIP_LONG_TESTS =
+        "true".equals(System.getProperty("project.skipExtendedHashTests"));
 
     /** The encryption method to test. */
     private EncryptionMethod method;
@@ -79,8 +88,10 @@ public abstract class AbstractEncryptionMethodTest {
 
     @Test
     public void testGivenPasswords() {
-        // Test all entries in GIVEN_PASSWORDS except the last one
-        for (int i = 0; i < GIVEN_PASSWORDS.length - 1; ++i) {
+        // Start with the 2nd to last password if we skip long tests
+        int start = SKIP_LONG_TESTS ? GIVEN_PASSWORDS.length - 2 : 0;
+        // Test entries in GIVEN_PASSWORDS except the last one
+        for (int i = start; i < GIVEN_PASSWORDS.length - 1; ++i) {
             String password = GIVEN_PASSWORDS[i];
             assertTrue("Hash for password '" + password + "' should match",
                 doesGivenHashMatch(password, method));
@@ -124,12 +135,14 @@ public abstract class AbstractEncryptionMethodTest {
                 assertFalse("Upper-case of '" + password + "' should not match generated hash '" + hash + "'",
                     method.comparePassword(password.toUpperCase(), hashedPassword, USERNAME));
             }
+            assumeThat(SKIP_LONG_TESTS, equalTo(false));
         }
     }
 
     /** Tests various strings to ensure that encryption methods don't rely on the hash's format too much. */
     @Test
     public void testMalformedHashes() {
+        assumeThat(SKIP_LONG_TESTS, equalTo(false));
         String salt = method.hasSeparateSalt() ? "testSalt" : null;
         for (String bogusHash : BOGUS_HASHES) {
             HashedPassword hashedPwd = new HashedPassword(bogusHash, salt);


### PR DESCRIPTION
- Set system property via surefire plugin and create profile that modifies the property
- Check for the new property in AbstractEncryptionMethodTest and shorten/skip the tests when necessary

@sgdc3 As the one who principally manages our POM, could I ask you to review this? This solution might not be desired. I'm very much open to improvements or alternative solutions.

fyi with the profile enabled the security package tests take 10s, without they take 32s.